### PR TITLE
First demo to showcase a vulnerable dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# JAVA-Maven-Dummy based on 
+https://github.com/jenkins-docs/simple-java-maven-app
+Demo-Case001 to test the impact of adding a dependency with a vulnerability.
+
+============================================
+
 # simple-java-maven-app
 
 This repository is for the


### PR DESCRIPTION
A vulnerable dependency log4j V2.14 was added in the pom-file in the compile-scope (but w/o functionality).